### PR TITLE
Add branded success message with spinner and growth CTAs

### DIFF
--- a/src/agent-resources/agent_resources/cli/agent.py
+++ b/src/agent-resources/agent_resources/cli/agent.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import typer
 
-from agent_resources.cli.common import get_destination, parse_resource_ref
+from agent_resources.cli.common import fetch_spinner, get_destination, parse_resource_ref, print_success_message
 from agent_resources.exceptions import (
     ClaudeAddError,
     RepoNotFoundError,
@@ -63,13 +63,12 @@ def add(
     dest = get_destination("agents", global_install)
     scope = "user" if global_install else "project"
 
-    typer.echo(f"Fetching agent '{agent_name}' from {username}/agent-resources...")
-
     try:
-        agent_path = fetch_resource(
-            username, agent_name, dest, ResourceType.AGENT, overwrite
-        )
-        typer.echo(f"Added agent '{agent_name}' to {agent_path} ({scope} scope)")
+        with fetch_spinner():
+            agent_path = fetch_resource(
+                username, agent_name, dest, ResourceType.AGENT, overwrite
+            )
+        print_success_message("agent", agent_name, username)
     except RepoNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/agent-resources/agent_resources/cli/command.py
+++ b/src/agent-resources/agent_resources/cli/command.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import typer
 
-from agent_resources.cli.common import get_destination, parse_resource_ref
+from agent_resources.cli.common import fetch_spinner, get_destination, parse_resource_ref, print_success_message
 from agent_resources.exceptions import (
     ClaudeAddError,
     RepoNotFoundError,
@@ -63,13 +63,12 @@ def add(
     dest = get_destination("commands", global_install)
     scope = "user" if global_install else "project"
 
-    typer.echo(f"Fetching command '{command_name}' from {username}/agent-resources...")
-
     try:
-        command_path = fetch_resource(
-            username, command_name, dest, ResourceType.COMMAND, overwrite
-        )
-        typer.echo(f"Added command '{command_name}' to {command_path} ({scope} scope)")
+        with fetch_spinner():
+            command_path = fetch_resource(
+                username, command_name, dest, ResourceType.COMMAND, overwrite
+            )
+        print_success_message("command", command_name, username)
     except RepoNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/agent-resources/agent_resources/cli/common.py
+++ b/src/agent-resources/agent_resources/cli/common.py
@@ -1,8 +1,15 @@
 """Shared CLI utilities for skill-add, command-add, and agent-add."""
 
+import random
+from contextlib import contextmanager
 from pathlib import Path
 
 import typer
+from rich.console import Console
+from rich.live import Live
+from rich.spinner import Spinner
+
+console = Console()
 
 
 def parse_resource_ref(ref: str) -> tuple[str, str]:
@@ -48,3 +55,21 @@ def get_destination(resource_subdir: str, global_install: bool) -> Path:
         base = Path.cwd() / ".claude"
 
     return base / resource_subdir
+
+
+@contextmanager
+def fetch_spinner():
+    """Show spinner during fetch operation."""
+    with Live(Spinner("dots", text="Fetching..."), console=console, transient=True):
+        yield
+
+
+def print_success_message(resource_type: str, name: str, username: str) -> None:
+    """Print branded success message with rotating CTA."""
+    console.print(f"✅ Added {resource_type} '{name}' via 🧩 agent-resources", style="dim")
+    ctas = [
+        f"💡 Create your own {resource_type} library on GitHub: uvx create-agent-resources-repo --github",
+        "⭐ Star: github.com/kasperjunge/agent-resources-project",
+        f"📢 Share: uvx add-{resource_type} {username}/{name}",
+    ]
+    console.print(random.choice(ctas), style="dim")

--- a/src/agent-resources/agent_resources/cli/skill.py
+++ b/src/agent-resources/agent_resources/cli/skill.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import typer
 
-from agent_resources.cli.common import get_destination, parse_resource_ref
+from agent_resources.cli.common import fetch_spinner, get_destination, parse_resource_ref, print_success_message
 from agent_resources.exceptions import (
     ClaudeAddError,
     RepoNotFoundError,
@@ -63,13 +63,12 @@ def add(
     dest = get_destination("skills", global_install)
     scope = "user" if global_install else "project"
 
-    typer.echo(f"Fetching skill '{skill_name}' from {username}/agent-resources...")
-
     try:
-        skill_path = fetch_resource(
-            username, skill_name, dest, ResourceType.SKILL, overwrite
-        )
-        typer.echo(f"Added skill '{skill_name}' to {skill_path} ({scope} scope)")
+        with fetch_spinner():
+            skill_path = fetch_resource(
+                username, skill_name, dest, ResourceType.SKILL, overwrite
+            )
+        print_success_message("skill", skill_name, username)
     except RepoNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/agent-resources/pyproject.toml
+++ b/src/agent-resources/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-resources"
-version = "0.2.0"
+version = "0.3.0"
 description = "Add Claude Code skills, commands, and agents from GitHub to your project"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -12,6 +12,7 @@ license = "MIT"
 dependencies = [
     "httpx>=0.27",
     "typer>=0.12",
+    "rich>=13.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Improve CLI UX with branded success messages and animated spinner. Every install now subtly encourages users to create, star, or share.

## Changes

- **CLI UX**: Add animated spinner during fetch operations (replaces verbose "Fetching..." message)
- **Branding**: New success message format: `✅ Added skill 'name' via 🧩 agent-resources`
- **CTAs**: Rotating call-to-actions on each install:
  - 💡 Create your own {type} library on GitHub
  - ⭐ Star the repo
  - 📢 Share command
- **Styling**: Dim output for cleaner, less intrusive terminal UX
- **Dependencies**: Add `rich>=13.0` for spinner and styled output

## Testing

- [x] Manual testing of skill/command/agent add commands
- [x] Verified spinner animation works
- [x] Verified CTA rotation

---

<sub>📋 PR description generated with [agent-resources](https://github.com/kasperjunge/agent-resources) • `uvx add-skill kasperjunge/pr`</sub>