### PR TITLE
Wire npm wrapper packages to agent-resources-npm core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ htmlcov/
 
 .notes/
 .claude/
+
+# Node.js
+node_modules/
+package-lock.json

--- a/command-packages/npm/create-agent-resources-repo/bin/create-agent-resources-repo.js
+++ b/command-packages/npm/create-agent-resources-repo/bin/create-agent-resources-repo.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createCreateCommand } from 'agent-resources/cli/create';
+createCreateCommand().parse();

--- a/command-packages/npm/create-agent-resources-repo/package.json
+++ b/command-packages/npm/create-agent-resources-repo/package.json
@@ -1,7 +1,14 @@
 {
   "name": "create-agent-resources-repo",
   "version": "0.0.1",
-  "description": "Scaffold a new agent-resources GitHub repository for sharing Claude Code skills, commands, and agents. Coming soon.",
+  "type": "module",
+  "description": "Scaffold a new agent-resources GitHub repository for sharing Claude Code skills, commands, and agents",
+  "bin": {
+    "create-agent-resources-repo": "./bin/create-agent-resources-repo.js"
+  },
+  "files": [
+    "bin"
+  ],
   "keywords": [
     "claude",
     "claude-code",
@@ -15,5 +22,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kasperjunge/agent-resources.git"
+  },
+  "dependencies": {
+    "agent-resources": "^0.0.1"
   }
 }

--- a/command-packages/npm/install-agent/bin/install-agent.js
+++ b/command-packages/npm/install-agent/bin/install-agent.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createAgentCommand } from 'agent-resources/cli/agent';
+createAgentCommand().parse();

--- a/command-packages/npm/install-agent/package.json
+++ b/command-packages/npm/install-agent/package.json
@@ -1,12 +1,27 @@
 {
   "name": "install-agent",
   "version": "0.0.1",
-  "description": "CLI tool for installing Claude Code agents from GitHub. Coming soon.",
-  "keywords": ["claude", "claude-code", "ai", "agent"],
+  "type": "module",
+  "description": "Install Claude Code agents from GitHub",
+  "bin": {
+    "install-agent": "./bin/install-agent.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "keywords": [
+    "claude",
+    "claude-code",
+    "ai",
+    "agent"
+  ],
   "author": "Kasper Junge",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/kasperjunge/agent-resources"
+  },
+  "dependencies": {
+    "agent-resources": "^0.0.1"
   }
 }

--- a/command-packages/npm/install-command/bin/install-command.js
+++ b/command-packages/npm/install-command/bin/install-command.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createCommandCommand } from 'agent-resources/cli/command';
+createCommandCommand().parse();

--- a/command-packages/npm/install-command/package.json
+++ b/command-packages/npm/install-command/package.json
@@ -1,12 +1,28 @@
 {
   "name": "install-command",
   "version": "0.0.1",
-  "description": "CLI tool for installing Claude Code commands from GitHub. Coming soon.",
-  "keywords": ["claude", "claude-code", "ai", "agent", "command"],
+  "type": "module",
+  "description": "Install Claude Code commands from GitHub",
+  "bin": {
+    "install-command": "./bin/install-command.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "keywords": [
+    "claude",
+    "claude-code",
+    "ai",
+    "agent",
+    "command"
+  ],
   "author": "Kasper Junge",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/kasperjunge/agent-resources"
+  },
+  "dependencies": {
+    "agent-resources": "^0.0.1"
   }
 }

--- a/command-packages/npm/install-skill/bin/install-skill.js
+++ b/command-packages/npm/install-skill/bin/install-skill.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createSkillCommand } from 'agent-resources/cli/skill';
+createSkillCommand().parse();

--- a/command-packages/npm/install-skill/package.json
+++ b/command-packages/npm/install-skill/package.json
@@ -1,7 +1,14 @@
 {
   "name": "install-skill",
   "version": "0.0.1",
-  "description": "CLI tool for installing Claude Code skills from GitHub. Coming soon.",
+  "type": "module",
+  "description": "Install Claude Code skills from GitHub",
+  "bin": {
+    "install-skill": "./bin/install-skill.js"
+  },
+  "files": [
+    "bin"
+  ],
   "keywords": [
     "claude",
     "claude-code",
@@ -14,5 +21,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kasperjunge/agent-resources.git"
+  },
+  "dependencies": {
+    "agent-resources": "^0.0.1"
   }
 }

--- a/src/agent-resources-npm/bin/add-agent.js
+++ b/src/agent-resources-npm/bin/add-agent.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createAgentCommand } from '../dist/cli/agent.js';
+createAgentCommand().parse();

--- a/src/agent-resources-npm/bin/add-command.js
+++ b/src/agent-resources-npm/bin/add-command.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createCommandCommand } from '../dist/cli/command.js';
+createCommandCommand().parse();

--- a/src/agent-resources-npm/bin/add-skill.js
+++ b/src/agent-resources-npm/bin/add-skill.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createSkillCommand } from '../dist/cli/skill.js';
+createSkillCommand().parse();

--- a/src/agent-resources-npm/bin/create-agent-resources-repo.js
+++ b/src/agent-resources-npm/bin/create-agent-resources-repo.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { createCreateCommand } from '../dist/cli/create.js';
+createCreateCommand().parse();

--- a/src/agent-resources-npm/package.json
+++ b/src/agent-resources-npm/package.json
@@ -1,7 +1,30 @@
 {
   "name": "agent-resources",
   "version": "0.0.1",
-  "description": "CLI tools for installing Claude Code resources (skills, commands, agents) from GitHub. Coming soon.",
+  "type": "module",
+  "description": "CLI tools for installing Claude Code resources (skills, commands, agents) from GitHub.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./cli/skill": "./dist/cli/skill.js",
+    "./cli/command": "./dist/cli/command.js",
+    "./cli/agent": "./dist/cli/agent.js",
+    "./cli/create": "./dist/cli/create.js"
+  },
+  "bin": {
+    "add-skill": "./bin/add-skill.js",
+    "add-command": "./bin/add-command.js",
+    "add-agent": "./bin/add-agent.js",
+    "create-agent-resources-repo": "./bin/create-agent-resources-repo.js"
+  },
+  "files": [
+    "dist",
+    "bin"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
   "keywords": [
     "claude",
     "claude-code",
@@ -15,5 +38,18 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kasperjunge/agent-resources.git"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "commander": "^12.0.0",
+    "fs-extra": "^11.2.0",
+    "ora": "^8.0.0",
+    "tar": "^7.0.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.0.0"
   }
 }

--- a/src/agent-resources-npm/src/cli/agent.ts
+++ b/src/agent-resources-npm/src/cli/agent.ts
@@ -1,0 +1,84 @@
+/**
+ * CLI for add-agent command.
+ */
+
+import { Command } from 'commander';
+import {
+  parseResourceRef,
+  getDestination,
+  createFetchSpinner,
+  printSuccessMessage,
+} from './common.js';
+import { fetchResource } from '../fetcher.js';
+import { ResourceType } from '../types.js';
+import {
+  ClaudeAddError,
+  RepoNotFoundError,
+  ResourceExistsError,
+  ResourceNotFoundError,
+} from '../exceptions.js';
+
+/**
+ * Create the add-agent CLI command.
+ */
+export function createAgentCommand(): Command {
+  const program = new Command()
+    .name('add-agent')
+    .description('Add Claude Code agents from GitHub to your project.')
+    .argument(
+      '<agent-ref>',
+      'Agent to add in format: <username>/<agent-name>'
+    )
+    .option('--overwrite', 'Overwrite existing agent if it exists.', false)
+    .option(
+      '-g, --global',
+      'Install to ~/.claude/ instead of ./.claude/',
+      false
+    )
+    .action(
+      async (
+        agentRef: string,
+        options: { overwrite: boolean; global: boolean }
+      ) => {
+        try {
+          const [username, agentName] = parseResourceRef(agentRef);
+          const dest = getDestination('agents', options.global);
+
+          const spinner = createFetchSpinner();
+          spinner.start();
+
+          try {
+            await fetchResource(
+              username,
+              agentName,
+              dest,
+              ResourceType.AGENT,
+              options.overwrite
+            );
+            spinner.stop();
+            printSuccessMessage('agent', agentName, username);
+          } catch (error) {
+            spinner.stop();
+            throw error;
+          }
+        } catch (error) {
+          if (
+            error instanceof RepoNotFoundError ||
+            error instanceof ResourceNotFoundError ||
+            error instanceof ResourceExistsError ||
+            error instanceof ClaudeAddError
+          ) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+          }
+          if (error instanceof Error) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+          }
+          throw error;
+        }
+      }
+    );
+
+  return program;
+}

--- a/src/agent-resources-npm/src/cli/command.ts
+++ b/src/agent-resources-npm/src/cli/command.ts
@@ -1,0 +1,84 @@
+/**
+ * CLI for add-command command.
+ */
+
+import { Command } from 'commander';
+import {
+  parseResourceRef,
+  getDestination,
+  createFetchSpinner,
+  printSuccessMessage,
+} from './common.js';
+import { fetchResource } from '../fetcher.js';
+import { ResourceType } from '../types.js';
+import {
+  ClaudeAddError,
+  RepoNotFoundError,
+  ResourceExistsError,
+  ResourceNotFoundError,
+} from '../exceptions.js';
+
+/**
+ * Create the add-command CLI command.
+ */
+export function createCommandCommand(): Command {
+  const program = new Command()
+    .name('add-command')
+    .description('Add Claude Code commands from GitHub to your project.')
+    .argument(
+      '<command-ref>',
+      'Command to add in format: <username>/<command-name>'
+    )
+    .option('--overwrite', 'Overwrite existing command if it exists.', false)
+    .option(
+      '-g, --global',
+      'Install to ~/.claude/ instead of ./.claude/',
+      false
+    )
+    .action(
+      async (
+        commandRef: string,
+        options: { overwrite: boolean; global: boolean }
+      ) => {
+        try {
+          const [username, commandName] = parseResourceRef(commandRef);
+          const dest = getDestination('commands', options.global);
+
+          const spinner = createFetchSpinner();
+          spinner.start();
+
+          try {
+            await fetchResource(
+              username,
+              commandName,
+              dest,
+              ResourceType.COMMAND,
+              options.overwrite
+            );
+            spinner.stop();
+            printSuccessMessage('command', commandName, username);
+          } catch (error) {
+            spinner.stop();
+            throw error;
+          }
+        } catch (error) {
+          if (
+            error instanceof RepoNotFoundError ||
+            error instanceof ResourceNotFoundError ||
+            error instanceof ResourceExistsError ||
+            error instanceof ClaudeAddError
+          ) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+          }
+          if (error instanceof Error) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+          }
+          throw error;
+        }
+      }
+    );
+
+  return program;
+}

--- a/src/agent-resources-npm/src/cli/common.ts
+++ b/src/agent-resources-npm/src/cli/common.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared CLI utilities for add-skill, add-command, and add-agent.
+ */
+
+import * as path from 'node:path';
+import * as os from 'node:os';
+import ora, { type Ora } from 'ora';
+import chalk from 'chalk';
+
+/**
+ * Parse '<username>/<name>' into components.
+ *
+ * @param ref - Resource reference in format 'username/name'
+ * @returns Tuple of [username, name]
+ * @throws Error if the format is invalid
+ */
+export function parseResourceRef(ref: string): [string, string] {
+  const parts = ref.split('/');
+  if (parts.length !== 2) {
+    throw new Error(`Invalid format: '${ref}'. Expected: <username>/<name>`);
+  }
+  const [username, name] = parts;
+  if (!username || !name) {
+    throw new Error(`Invalid format: '${ref}'. Expected: <username>/<name>`);
+  }
+  return [username, name];
+}
+
+/**
+ * Get the destination directory for a resource.
+ *
+ * @param resourceSubdir - The subdirectory name (e.g., "skills", "commands", "agents")
+ * @param globalInstall - If true, install to ~/.claude/, else to ./.claude/
+ * @returns Path to the destination directory
+ */
+export function getDestination(
+  resourceSubdir: string,
+  globalInstall: boolean
+): string {
+  let base: string;
+  if (globalInstall) {
+    base = path.join(os.homedir(), '.claude');
+  } else {
+    base = path.join(process.cwd(), '.claude');
+  }
+  return path.join(base, resourceSubdir);
+}
+
+/**
+ * Create a spinner for fetch operations.
+ */
+export function createFetchSpinner(): Ora {
+  return ora({ text: 'Fetching...', spinner: 'dots' });
+}
+
+/**
+ * Print branded success message with rotating CTA.
+ */
+export function printSuccessMessage(
+  resourceType: string,
+  name: string,
+  username: string
+): void {
+  console.log(
+    chalk.dim(`✅ Added ${resourceType} '${name}' via 🧩 agent-resources`)
+  );
+
+  const ctas = [
+    `💡 Create your own ${resourceType} library on GitHub: npx create-agent-resources-repo --github`,
+    '⭐ Star: github.com/kasperjunge/agent-resources-project',
+    `📢 Share: npx install-${resourceType} ${username}/${name}`,
+  ];
+
+  const randomCta = ctas[Math.floor(Math.random() * ctas.length)];
+  console.log(chalk.dim(randomCta));
+}

--- a/src/agent-resources-npm/src/cli/create.ts
+++ b/src/agent-resources-npm/src/cli/create.ts
@@ -1,0 +1,112 @@
+/**
+ * CLI for create-agent-resources-repo command.
+ */
+
+import * as path from 'node:path';
+import * as fs from 'fs-extra';
+import { Command } from 'commander';
+import {
+  checkGhCli,
+  createGithubRepo,
+  getGithubUsername,
+  repoExists,
+} from '../github.js';
+import { createAgentResourcesRepo, initGit } from '../scaffold.js';
+
+/**
+ * Create the create-agent-resources-repo CLI command.
+ */
+export function createCreateCommand(): Command {
+  const program = new Command()
+    .name('create-agent-resources-repo')
+    .description('Create a personal agent-resources repository.')
+    .option(
+      '-p, --path <path>',
+      'Directory to create (default: ./agent-resources)'
+    )
+    .option(
+      '-g, --github',
+      'Create GitHub repository and push (requires gh CLI)',
+      false
+    )
+    .action(async (options: { path?: string; github: boolean }) => {
+      // Determine output path
+      const outputPath =
+        options.path || path.join(process.cwd(), 'agent-resources');
+
+      // Check if directory already exists
+      if (await fs.pathExists(outputPath)) {
+        console.error(`Error: Directory already exists: ${outputPath}`);
+        process.exit(1);
+      }
+
+      // Get username for README (if GitHub integration enabled)
+      let username = '<username>';
+      if (options.github) {
+        if (!checkGhCli()) {
+          console.error(
+            'Error: GitHub CLI (gh) is not installed or not authenticated.'
+          );
+          console.error('Install: https://cli.github.com/');
+          console.error('Then run: gh auth login');
+          process.exit(1);
+        }
+
+        // Check if repo already exists on GitHub
+        if (repoExists()) {
+          console.error(
+            "Error: Repository 'agent-resources' already exists on GitHub."
+          );
+          console.error('Delete it first or use a different approach.');
+          process.exit(1);
+        }
+
+        username = getGithubUsername() || '<username>';
+      }
+
+      // Create the repository structure
+      console.log(`Creating agent-resources repository at ${outputPath}...`);
+      await createAgentResourcesRepo(outputPath, username);
+      console.log('  Created directory structure');
+      console.log('  Added hello-world skill');
+      console.log('  Added hello command');
+      console.log('  Added hello-agent agent');
+      console.log('  Created README.md');
+
+      // Initialize git
+      if (initGit(outputPath)) {
+        console.log('  Initialized git repository');
+      } else {
+        console.error('  Warning: Could not initialize git repository');
+      }
+
+      // GitHub integration
+      if (options.github) {
+        console.log('Creating GitHub repository...');
+        const repoUrl = createGithubRepo(outputPath);
+        if (repoUrl) {
+          console.log(`  Pushed to ${repoUrl}`);
+          console.log('');
+          console.log('Your agent-resources repo is ready!');
+          console.log('Others can now install your resources:');
+          console.log(`  npx install-skill ${username}/hello-world`);
+          console.log(`  npx install-command ${username}/hello`);
+          console.log(`  npx install-agent ${username}/hello-agent`);
+        } else {
+          console.error('  Error: Could not create GitHub repository');
+          process.exit(1);
+        }
+      } else {
+        console.log('');
+        console.log('Next steps:');
+        console.log("  1. Create a GitHub repository named 'agent-resources'");
+        console.log(`  2. cd ${outputPath}`);
+        console.log('  3. git remote add origin <your-repo-url>');
+        console.log('  4. git push -u origin main');
+        console.log('');
+        console.log('Or use --github flag to automate this (requires gh CLI)');
+      }
+    });
+
+  return program;
+}

--- a/src/agent-resources-npm/src/cli/skill.ts
+++ b/src/agent-resources-npm/src/cli/skill.ts
@@ -1,0 +1,84 @@
+/**
+ * CLI for add-skill command.
+ */
+
+import { Command } from 'commander';
+import {
+  parseResourceRef,
+  getDestination,
+  createFetchSpinner,
+  printSuccessMessage,
+} from './common.js';
+import { fetchResource } from '../fetcher.js';
+import { ResourceType } from '../types.js';
+import {
+  ClaudeAddError,
+  RepoNotFoundError,
+  ResourceExistsError,
+  ResourceNotFoundError,
+} from '../exceptions.js';
+
+/**
+ * Create the add-skill CLI command.
+ */
+export function createSkillCommand(): Command {
+  const program = new Command()
+    .name('add-skill')
+    .description('Add Claude Code skills from GitHub to your project.')
+    .argument(
+      '<skill-ref>',
+      'Skill to add in format: <username>/<skill-name>'
+    )
+    .option('--overwrite', 'Overwrite existing skill if it exists.', false)
+    .option(
+      '-g, --global',
+      'Install to ~/.claude/ instead of ./.claude/',
+      false
+    )
+    .action(
+      async (
+        skillRef: string,
+        options: { overwrite: boolean; global: boolean }
+      ) => {
+        try {
+          const [username, skillName] = parseResourceRef(skillRef);
+          const dest = getDestination('skills', options.global);
+
+          const spinner = createFetchSpinner();
+          spinner.start();
+
+          try {
+            await fetchResource(
+              username,
+              skillName,
+              dest,
+              ResourceType.SKILL,
+              options.overwrite
+            );
+            spinner.stop();
+            printSuccessMessage('skill', skillName, username);
+          } catch (error) {
+            spinner.stop();
+            throw error;
+          }
+        } catch (error) {
+          if (
+            error instanceof RepoNotFoundError ||
+            error instanceof ResourceNotFoundError ||
+            error instanceof ResourceExistsError ||
+            error instanceof ClaudeAddError
+          ) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+          }
+          if (error instanceof Error) {
+            console.error(`Error: ${error.message}`);
+            process.exit(1);
+          }
+          throw error;
+        }
+      }
+    );
+
+  return program;
+}

--- a/src/agent-resources-npm/src/exceptions.ts
+++ b/src/agent-resources-npm/src/exceptions.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared exception classes for agent-resources.
+ */
+
+/**
+ * Base exception for claude-add errors.
+ */
+export class ClaudeAddError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClaudeAddError';
+    Object.setPrototypeOf(this, ClaudeAddError.prototype);
+  }
+}
+
+/**
+ * Raised when the agent-resources repo doesn't exist.
+ */
+export class RepoNotFoundError extends ClaudeAddError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RepoNotFoundError';
+    Object.setPrototypeOf(this, RepoNotFoundError.prototype);
+  }
+}
+
+/**
+ * Raised when the skill/command/agent doesn't exist in the repo.
+ */
+export class ResourceNotFoundError extends ClaudeAddError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResourceNotFoundError';
+    Object.setPrototypeOf(this, ResourceNotFoundError.prototype);
+  }
+}
+
+/**
+ * Raised when the resource already exists locally.
+ */
+export class ResourceExistsError extends ClaudeAddError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResourceExistsError';
+    Object.setPrototypeOf(this, ResourceExistsError.prototype);
+  }
+}

--- a/src/agent-resources-npm/src/fetcher.ts
+++ b/src/agent-resources-npm/src/fetcher.ts
@@ -1,0 +1,154 @@
+/**
+ * Generic resource fetcher for skills, commands, and agents.
+ */
+
+import { createWriteStream } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import * as fs from 'fs-extra';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { Readable } from 'node:stream';
+import * as tar from 'tar';
+
+import {
+  ClaudeAddError,
+  RepoNotFoundError,
+  ResourceExistsError,
+  ResourceNotFoundError,
+} from './exceptions.js';
+import { ResourceType, RESOURCE_CONFIGS, REPO_NAME } from './types.js';
+
+/**
+ * Capitalize the first letter of a string.
+ */
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+/**
+ * Fetch a resource from a user's agent-resources repo and copy it to dest.
+ *
+ * @param username - GitHub username
+ * @param name - Name of the resource to fetch
+ * @param dest - Destination directory (e.g., .claude/skills/, .claude/commands/)
+ * @param resourceType - Type of resource (SKILL, COMMAND, or AGENT)
+ * @param overwrite - Whether to overwrite existing resource
+ * @returns Path to the installed resource
+ * @throws RepoNotFoundError - If the agent-resources repo doesn't exist
+ * @throws ResourceNotFoundError - If the resource doesn't exist in the repo
+ * @throws ResourceExistsError - If resource exists locally and overwrite=false
+ */
+export async function fetchResource(
+  username: string,
+  name: string,
+  dest: string,
+  resourceType: ResourceType,
+  overwrite: boolean = false
+): Promise<string> {
+  const config = RESOURCE_CONFIGS[resourceType];
+
+  // Determine destination path
+  let resourceDest: string;
+  if (config.isDirectory) {
+    resourceDest = path.join(dest, name);
+  } else {
+    resourceDest = path.join(dest, `${name}${config.fileExtension}`);
+  }
+
+  // Check if resource already exists locally
+  if ((await fs.pathExists(resourceDest)) && !overwrite) {
+    throw new ResourceExistsError(
+      `${capitalize(resourceType)} '${name}' already exists at ${resourceDest}\n` +
+        `Use --overwrite to replace it.`
+    );
+  }
+
+  // Download tarball
+  const tarballUrl = `https://github.com/${username}/${REPO_NAME}/archive/refs/heads/main.tar.gz`;
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'agent-resources-'));
+
+  try {
+    const tarballPath = path.join(tmpDir, 'repo.tar.gz');
+
+    // Download
+    let response: Response;
+    try {
+      response = await fetch(tarballUrl, { redirect: 'follow' });
+    } catch (error) {
+      throw new ClaudeAddError(`Network error: ${error}`);
+    }
+
+    if (response.status === 404) {
+      throw new RepoNotFoundError(
+        `Repository '${username}/${REPO_NAME}' not found on GitHub.`
+      );
+    }
+
+    if (!response.ok) {
+      throw new ClaudeAddError(
+        `Failed to download repository: HTTP ${response.status}`
+      );
+    }
+
+    // Write to file
+    const body = response.body;
+    if (!body) {
+      throw new ClaudeAddError('Empty response body');
+    }
+
+    await pipeline(
+      Readable.fromWeb(body as Parameters<typeof Readable.fromWeb>[0]),
+      createWriteStream(tarballPath)
+    );
+
+    // Extract
+    const extractPath = path.join(tmpDir, 'extracted');
+    await fs.ensureDir(extractPath);
+    await tar.extract({ file: tarballPath, cwd: extractPath });
+
+    // Find the resource in extracted content
+    // Tarball extracts to: agent-resources-main/.claude/<type>/<name>[.md]
+    const repoDir = path.join(extractPath, `${REPO_NAME}-main`);
+
+    let resourceSource: string;
+    if (config.isDirectory) {
+      resourceSource = path.join(repoDir, config.sourceSubdir, name);
+    } else {
+      resourceSource = path.join(
+        repoDir,
+        config.sourceSubdir,
+        `${name}${config.fileExtension}`
+      );
+    }
+
+    if (!(await fs.pathExists(resourceSource))) {
+      let expectedLocation: string;
+      if (config.isDirectory) {
+        expectedLocation = `${config.sourceSubdir}/${name}/`;
+      } else {
+        expectedLocation = `${config.sourceSubdir}/${name}${config.fileExtension}`;
+      }
+      throw new ResourceNotFoundError(
+        `${capitalize(resourceType)} '${name}' not found in ${username}/${REPO_NAME}.\n` +
+          `Expected location: ${expectedLocation}`
+      );
+    }
+
+    // Remove existing if overwriting
+    if (await fs.pathExists(resourceDest)) {
+      await fs.remove(resourceDest);
+    }
+
+    // Ensure destination parent exists
+    await fs.ensureDir(dest);
+
+    // Copy resource to destination
+    await fs.copy(resourceSource, resourceDest);
+
+    return resourceDest;
+  } finally {
+    // Cleanup temp directory
+    await fs.remove(tmpDir);
+  }
+}

--- a/src/agent-resources-npm/src/github.ts
+++ b/src/agent-resources-npm/src/github.ts
@@ -1,0 +1,97 @@
+/**
+ * GitHub CLI integration for creating and pushing repositories.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Check if GitHub CLI is available and authenticated.
+ *
+ * @returns True if gh CLI is installed and authenticated, false otherwise.
+ */
+export function checkGhCli(): boolean {
+  try {
+    const result = spawnSync('gh', ['auth', 'status'], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get the authenticated GitHub username.
+ *
+ * @returns The username if authenticated, null otherwise.
+ */
+export function getGithubUsername(): string | null {
+  try {
+    const result = spawnSync('gh', ['api', 'user', '--jq', '.login'], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    if (result.status === 0 && result.stdout) {
+      return result.stdout.trim();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create a GitHub repository and push the local repo.
+ *
+ * @param repoPath - Path to the local git repository
+ * @param repoName - Name for the GitHub repository (default: agent-resources)
+ * @returns The GitHub repo URL if successful, null otherwise.
+ */
+export function createGithubRepo(
+  repoPath: string,
+  repoName: string = 'agent-resources'
+): string | null {
+  try {
+    // Create repo on GitHub (public by default)
+    const result = spawnSync(
+      'gh',
+      ['repo', 'create', repoName, '--public', '--source', repoPath, '--push'],
+      {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }
+    );
+
+    if (result.status !== 0) {
+      return null;
+    }
+
+    // Extract URL from output or construct it
+    const username = getGithubUsername();
+    if (username) {
+      return `https://github.com/${username}/${repoName}`;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a repository with the given name already exists.
+ *
+ * @returns True if the repo exists, false otherwise.
+ */
+export function repoExists(repoName: string = 'agent-resources'): boolean {
+  try {
+    const result = spawnSync('gh', ['repo', 'view', repoName], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/agent-resources-npm/src/index.ts
+++ b/src/agent-resources-npm/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * agent-resources - CLI tools for installing Claude Code resources from GitHub.
+ */
+
+// Types
+export { ResourceType, RESOURCE_CONFIGS, REPO_NAME } from './types.js';
+export type { ResourceConfig } from './types.js';
+
+// Exceptions
+export {
+  ClaudeAddError,
+  RepoNotFoundError,
+  ResourceNotFoundError,
+  ResourceExistsError,
+} from './exceptions.js';
+
+// Core functionality
+export { fetchResource } from './fetcher.js';
+
+// GitHub integration
+export {
+  checkGhCli,
+  getGithubUsername,
+  createGithubRepo,
+  repoExists,
+} from './github.js';
+
+// Scaffolding
+export {
+  scaffoldRepo,
+  writeStarterSkill,
+  writeStarterCommand,
+  writeStarterAgent,
+  writeReadme,
+  writeGitignore,
+  initGit,
+  createAgentResourcesRepo,
+} from './scaffold.js';
+
+// CLI utilities
+export {
+  parseResourceRef,
+  getDestination,
+  createFetchSpinner,
+  printSuccessMessage,
+} from './cli/common.js';
+
+// CLI commands
+export { createSkillCommand } from './cli/skill.js';
+export { createCommandCommand } from './cli/command.js';
+export { createAgentCommand } from './cli/agent.js';
+export { createCreateCommand } from './cli/create.js';

--- a/src/agent-resources-npm/src/scaffold.ts
+++ b/src/agent-resources-npm/src/scaffold.ts
@@ -1,0 +1,229 @@
+/**
+ * Scaffolding functions for creating agent-resources repository structure.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import * as fs from 'fs-extra';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const HELLO_SKILL = `\
+---
+name: hello-world
+description: A simple example skill that demonstrates Claude Code skill structure
+---
+
+# Hello World Skill
+
+This is a demonstration skill showing how skills work.
+
+## When to Use
+
+Apply this skill when the user asks you to say hello or demonstrate skills.
+
+## Instructions
+
+Respond with a friendly greeting explaining this came from a skill.
+`;
+
+const HELLO_COMMAND = `\
+---
+description: Say hello - example slash command
+---
+
+When the user runs /hello, respond with a friendly greeting.
+Explain that this is an example command from their agent-resources repo.
+`;
+
+const HELLO_AGENT = `\
+---
+description: Example subagent that greets users
+---
+
+You are a friendly greeter subagent.
+When invoked, introduce yourself and explain that you're an example agent
+from the user's agent-resources repository.
+`;
+
+const README_TEMPLATE = `\
+# agent-resources
+
+My personal collection of Claude Code skills, commands, and agents.
+
+## Structure
+
+\`\`\`
+.claude/
+├── skills/       # Skill directories with SKILL.md
+├── commands/     # Slash command .md files
+└── agents/       # Subagent .md files
+\`\`\`
+
+## Usage
+
+Others can install my resources using:
+
+\`\`\`bash
+# Install a skill
+npx install-skill {username}/hello-world
+
+# Install a command
+npx install-command {username}/hello
+
+# Install an agent
+npx install-agent {username}/hello-agent
+\`\`\`
+
+## Adding Resources
+
+- **Skills**: Create a directory in \`.claude/skills/<name>/\` with a \`SKILL.md\` file
+- **Commands**: Create a \`.md\` file in \`.claude/commands/\`
+- **Agents**: Create a \`.md\` file in \`.claude/agents/\`
+
+## Learn More
+
+- [agent-resources documentation](https://github.com/kasperjunge/agent-resources-project)
+`;
+
+const GITIGNORE = `\
+# Node
+node_modules/
+*.log
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.env
+.venv/
+venv/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+`;
+
+/**
+ * Create the complete agent-resources directory structure.
+ */
+export async function scaffoldRepo(repoPath: string): Promise<void> {
+  await fs.ensureDir(repoPath);
+
+  // Create .claude directory structure
+  const claudeDir = path.join(repoPath, '.claude');
+  await fs.ensureDir(path.join(claudeDir, 'skills', 'hello-world'));
+  await fs.ensureDir(path.join(claudeDir, 'commands'));
+  await fs.ensureDir(path.join(claudeDir, 'agents'));
+}
+
+/**
+ * Write the hello-world example skill.
+ */
+export async function writeStarterSkill(repoPath: string): Promise<void> {
+  const skillPath = path.join(
+    repoPath,
+    '.claude',
+    'skills',
+    'hello-world',
+    'SKILL.md'
+  );
+  await writeFile(skillPath, HELLO_SKILL, 'utf8');
+}
+
+/**
+ * Write the hello example command.
+ */
+export async function writeStarterCommand(repoPath: string): Promise<void> {
+  const commandPath = path.join(repoPath, '.claude', 'commands', 'hello.md');
+  await writeFile(commandPath, HELLO_COMMAND, 'utf8');
+}
+
+/**
+ * Write the hello-agent example agent.
+ */
+export async function writeStarterAgent(repoPath: string): Promise<void> {
+  const agentPath = path.join(repoPath, '.claude', 'agents', 'hello-agent.md');
+  await writeFile(agentPath, HELLO_AGENT, 'utf8');
+}
+
+/**
+ * Write the README.md file.
+ */
+export async function writeReadme(
+  repoPath: string,
+  username: string = '<username>'
+): Promise<void> {
+  const readmePath = path.join(repoPath, 'README.md');
+  await writeFile(
+    readmePath,
+    README_TEMPLATE.replace(/{username}/g, username),
+    'utf8'
+  );
+}
+
+/**
+ * Write the .gitignore file.
+ */
+export async function writeGitignore(repoPath: string): Promise<void> {
+  const gitignorePath = path.join(repoPath, '.gitignore');
+  await writeFile(gitignorePath, GITIGNORE, 'utf8');
+}
+
+/**
+ * Initialize git repository and create initial commit.
+ *
+ * @returns True if successful, false otherwise.
+ */
+export function initGit(repoPath: string): boolean {
+  try {
+    let result = spawnSync('git', ['init'], {
+      cwd: repoPath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    if (result.status !== 0) return false;
+
+    result = spawnSync('git', ['add', '.'], {
+      cwd: repoPath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+    if (result.status !== 0) return false;
+
+    result = spawnSync(
+      'git',
+      ['commit', '-m', 'Initial commit: agent-resources repo scaffold'],
+      {
+        cwd: repoPath,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }
+    );
+    if (result.status !== 0) return false;
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create a complete agent-resources repository with all starter content.
+ */
+export async function createAgentResourcesRepo(
+  repoPath: string,
+  username: string = '<username>'
+): Promise<void> {
+  await scaffoldRepo(repoPath);
+  await writeStarterSkill(repoPath);
+  await writeStarterCommand(repoPath);
+  await writeStarterAgent(repoPath);
+  await writeReadme(repoPath, username);
+  await writeGitignore(repoPath);
+}

--- a/src/agent-resources-npm/src/types.ts
+++ b/src/agent-resources-npm/src/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Type definitions for agent-resources.
+ */
+
+/**
+ * Type of resource to fetch.
+ */
+export enum ResourceType {
+  SKILL = 'skill',
+  COMMAND = 'command',
+  AGENT = 'agent',
+}
+
+/**
+ * Configuration for a resource type.
+ */
+export interface ResourceConfig {
+  resourceType: ResourceType;
+  sourceSubdir: string; // e.g., ".claude/skills", ".claude/commands"
+  destSubdir: string; // e.g., "skills", "commands"
+  isDirectory: boolean; // True for skills, False for commands/agents
+  fileExtension: string | null; // null for skills, ".md" for commands/agents
+}
+
+/**
+ * Configuration mapping for each resource type.
+ */
+export const RESOURCE_CONFIGS: Record<ResourceType, ResourceConfig> = {
+  [ResourceType.SKILL]: {
+    resourceType: ResourceType.SKILL,
+    sourceSubdir: '.claude/skills',
+    destSubdir: 'skills',
+    isDirectory: true,
+    fileExtension: null,
+  },
+  [ResourceType.COMMAND]: {
+    resourceType: ResourceType.COMMAND,
+    sourceSubdir: '.claude/commands',
+    destSubdir: 'commands',
+    isDirectory: false,
+    fileExtension: '.md',
+  },
+  [ResourceType.AGENT]: {
+    resourceType: ResourceType.AGENT,
+    sourceSubdir: '.claude/agents',
+    destSubdir: 'agents',
+    isDirectory: false,
+    fileExtension: '.md',
+  },
+};
+
+/**
+ * Name of the repository to fetch resources from.
+ */
+export const REPO_NAME = 'agent-resources';

--- a/src/agent-resources-npm/tsconfig.json
+++ b/src/agent-resources-npm/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/src/agent-resources-npm/tsup.config.ts
+++ b/src/agent-resources-npm/tsup.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/cli/skill.ts',
+    'src/cli/command.ts',
+    'src/cli/agent.ts',
+    'src/cli/create.ts',
+  ],
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'node18',
+  splitting: false,
+});


### PR DESCRIPTION
## Summary

Connect the npm wrapper packages (`install-skill`, `install-command`, `install-agent`, `create-agent-resources-repo`) to the core `agent-resources` npm package, enabling the `npx install-skill <username>/<skill>` UX. This mirrors the Python architecture where wrapper packages depend on and re-export CLI commands from the core library.

## Changes

- **Core package** (`src/agent-resources-npm/`):
  - Add `type: "module"`, `exports`, `bin`, `files` fields to package.json
  - Add runtime dependencies: `chalk`, `commander`, `fs-extra`, `ora`, `tar`
  - Add dev dependencies: `@types/fs-extra`, `@types/node`, `tsup`, `typescript`
  - Include TypeScript source files and bin entry points

- **Wrapper packages** (`command-packages/npm/`):
  - Add `type: "module"`, `bin`, `files` fields to each package.json
  - Add dependency on `agent-resources` core package
  - Include bin scripts that import from `agent-resources/cli/*`

- **Build config**:
  - Add `tsconfig.json` and `tsup.config.ts` for TypeScript compilation
  - Add `node_modules/` and `package-lock.json` to `.gitignore`

## Testing

- [x] `npm install` succeeds in core package
- [x] `npm run build` compiles TypeScript without errors
- [x] All 4 CLI commands work via `node bin/<command>.js --help`
- [x] End-to-end test: fetch attempt connects to GitHub and returns proper error for missing resource

## Notes for Reviewers

- The TypeScript implementation was already present but uncommitted; this PR includes those source files
- Wrapper packages use `npm link` for local development; after publishing `agent-resources` to npm, they'll resolve normally
- The architecture matches the Python side: thin wrappers that re-export CLI commands from the core library

---

<sub>📋 PR description generated with [agent-resources](https://github.com/kasperjunge/agent-resources) • `uvx add-skill kasperjunge/pr`</sub>