### PR TITLE
Add support for custom repository names in resource references

### DIFF
--- a/src/agent-resources/agent_resources/cli/agent.py
+++ b/src/agent-resources/agent_resources/cli/agent.py
@@ -24,8 +24,8 @@ def add(
     agent_ref: Annotated[
         str,
         typer.Argument(
-            help="Agent to add in format: <username>/<agent-name>",
-            metavar="USERNAME/AGENT-NAME",
+            help="Agent to add: <username>/<agent-name> or <username>/<repo>/<agent-name>",
+            metavar="USERNAME/[REPO/]AGENT-NAME",
         ),
     ],
     overwrite: Annotated[
@@ -45,30 +45,30 @@ def add(
     ] = False,
 ) -> None:
     """
-    Add a sub-agent from a GitHub user's agent-resources repository.
+    Add a sub-agent from a GitHub repository.
 
     The agent will be copied to .claude/agents/<agent-name>.md in the
     current directory (or ~/.claude/agents/ with --global).
 
     Example:
         add-agent kasperjunge/code-reviewer
+        add-agent kasperjunge/my-repo/code-reviewer
         add-agent kasperjunge/test-writer --global
     """
     try:
-        username, agent_name = parse_resource_ref(agent_ref)
+        username, repo_name, agent_name = parse_resource_ref(agent_ref)
     except typer.BadParameter as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
     dest = get_destination("agents", global_install)
-    scope = "user" if global_install else "project"
 
     try:
         with fetch_spinner():
             agent_path = fetch_resource(
-                username, agent_name, dest, ResourceType.AGENT, overwrite
+                username, repo_name, agent_name, dest, ResourceType.AGENT, overwrite
             )
-        print_success_message("agent", agent_name, username)
+        print_success_message("agent", agent_name, username, repo_name)
     except RepoNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/agent-resources/agent_resources/cli/command.py
+++ b/src/agent-resources/agent_resources/cli/command.py
@@ -24,8 +24,8 @@ def add(
     command_ref: Annotated[
         str,
         typer.Argument(
-            help="Command to add in format: <username>/<command-name>",
-            metavar="USERNAME/COMMAND-NAME",
+            help="Command to add: <username>/<command-name> or <username>/<repo>/<command-name>",
+            metavar="USERNAME/[REPO/]COMMAND-NAME",
         ),
     ],
     overwrite: Annotated[
@@ -45,30 +45,30 @@ def add(
     ] = False,
 ) -> None:
     """
-    Add a slash command from a GitHub user's agent-resources repository.
+    Add a slash command from a GitHub repository.
 
     The command will be copied to .claude/commands/<command-name>.md in the
     current directory (or ~/.claude/commands/ with --global).
 
     Example:
         add-command kasperjunge/commit
+        add-command kasperjunge/my-repo/commit
         add-command kasperjunge/review-pr --global
     """
     try:
-        username, command_name = parse_resource_ref(command_ref)
+        username, repo_name, command_name = parse_resource_ref(command_ref)
     except typer.BadParameter as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
     dest = get_destination("commands", global_install)
-    scope = "user" if global_install else "project"
 
     try:
         with fetch_spinner():
             command_path = fetch_resource(
-                username, command_name, dest, ResourceType.COMMAND, overwrite
+                username, repo_name, command_name, dest, ResourceType.COMMAND, overwrite
             )
-        print_success_message("command", command_name, username)
+        print_success_message("command", command_name, username, repo_name)
     except RepoNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)

--- a/src/agent-resources/agent_resources/cli/skill.py
+++ b/src/agent-resources/agent_resources/cli/skill.py
@@ -24,8 +24,8 @@ def add(
     skill_ref: Annotated[
         str,
         typer.Argument(
-            help="Skill to add in format: <username>/<skill-name>",
-            metavar="USERNAME/SKILL-NAME",
+            help="Skill to add: <username>/<skill-name> or <username>/<repo>/<skill-name>",
+            metavar="USERNAME/[REPO/]SKILL-NAME",
         ),
     ],
     overwrite: Annotated[
@@ -45,30 +45,30 @@ def add(
     ] = False,
 ) -> None:
     """
-    Add a skill from a GitHub user's agent-resources repository.
+    Add a skill from a GitHub repository.
 
     The skill will be copied to .claude/skills/<skill-name>/ in the current
     directory (or ~/.claude/skills/ with --global).
 
     Example:
         add-skill kasperjunge/analyze-paper
+        add-skill kasperjunge/my-repo/analyze-paper
         add-skill kasperjunge/analyze-paper --global
     """
     try:
-        username, skill_name = parse_resource_ref(skill_ref)
+        username, repo_name, skill_name = parse_resource_ref(skill_ref)
     except typer.BadParameter as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)
 
     dest = get_destination("skills", global_install)
-    scope = "user" if global_install else "project"
 
     try:
         with fetch_spinner():
             skill_path = fetch_resource(
-                username, skill_name, dest, ResourceType.SKILL, overwrite
+                username, repo_name, skill_name, dest, ResourceType.SKILL, overwrite
             )
-        print_success_message("skill", skill_name, username)
+        print_success_message("skill", skill_name, username, repo_name)
     except RepoNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

Enable fetching agent resources from any GitHub repository with a `.claude/` directory, not just repos named `agent-resources`. This provides more flexibility for users who want to organize their resources in project-specific repositories.

## Changes

- **CLI Parsing (`cli/common.py`)**: `parse_resource_ref()` now supports both 2-part and 3-part formats, returning a 3-tuple `(username, repo_name, resource_name)`
- **Fetcher (`fetcher.py`)**: `fetch_resource()` accepts a `repo_name` parameter to construct the GitHub tarball URL dynamically
- **CLI Commands**: Updated `add-skill`, `add-command`, and `add-agent` with new help text, examples, and function signatures

**New Usage:**
```bash
# 2-part format (defaults to agent-resources repo) - unchanged
uvx add-skill kasperjunge/analyze-paper

# 3-part format (custom repo) - NEW
uvx add-skill kasperjunge/my-project/analyze-paper
```

## Testing

- [x] Python syntax validation passes
- [x] CLI help output shows updated format: `USERNAME/[REPO/]SKILL-NAME`
- [x] `parse_resource_ref()` correctly parses both 2-part and 3-part formats
- [ ] Manual test: fetch from default `agent-resources` repo
- [ ] Manual test: fetch from custom repo with `.claude/` directory

## Notes for Reviewers

- Fully backward compatible: existing 2-part references work exactly as before
- The success message "Share" CTA dynamically shows the correct format based on whether a custom repo was used
- Removed unused `scope` variable from CLI commands (was assigned but never used)

---

<sub>📋 PR description generated with [agent-resources](https://github.com/kasperjunge/agent-resources) • `uvx add-skill kasperjunge/pr`</sub>