### PR TITLE
feat: add `agr update` and `agr remove` commands

### DIFF
--- a/src/agr/agr/cli/main.py
+++ b/src/agr/agr/cli/main.py
@@ -4,6 +4,8 @@ import typer
 
 from agr.cli.add import app as add_app
 from agr.cli.init import app as init_app
+from agr.cli.remove import app as remove_app
+from agr.cli.update import app as update_app
 
 app = typer.Typer(
     name="agr",
@@ -15,6 +17,8 @@ app = typer.Typer(
 # Register subcommands
 app.add_typer(add_app, name="add")
 app.add_typer(init_app, name="init")
+app.add_typer(remove_app, name="remove")
+app.add_typer(update_app, name="update")
 
 
 def main() -> None:

--- a/src/agr/agr/cli/remove.py
+++ b/src/agr/agr/cli/remove.py
@@ -1,0 +1,100 @@
+"""Remove subcommand for agr - delete local resources."""
+
+from typing import Annotated
+
+import typer
+
+from agr.cli.common import handle_remove_resource
+from agr.fetcher import ResourceType
+
+app = typer.Typer(
+    help="Remove skills, commands, or agents.",
+    no_args_is_help=True,
+)
+
+
+@app.command("skill")
+def remove_skill(
+    name: Annotated[
+        str,
+        typer.Argument(
+            help="Name of the skill to remove",
+            metavar="NAME",
+        ),
+    ],
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            "-g",
+            help="Remove from ~/.claude/ instead of ./.claude/",
+        ),
+    ] = False,
+) -> None:
+    """Remove a skill from the local installation.
+
+    Removes the skill directory immediately without confirmation.
+
+    Examples:
+      agr remove skill hello-world
+      agr remove skill hello-world --global
+    """
+    handle_remove_resource(name, ResourceType.SKILL, "skills", global_install)
+
+
+@app.command("command")
+def remove_command(
+    name: Annotated[
+        str,
+        typer.Argument(
+            help="Name of the command to remove",
+            metavar="NAME",
+        ),
+    ],
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            "-g",
+            help="Remove from ~/.claude/ instead of ./.claude/",
+        ),
+    ] = False,
+) -> None:
+    """Remove a slash command from the local installation.
+
+    Removes the command file immediately without confirmation.
+
+    Examples:
+      agr remove command hello
+      agr remove command hello --global
+    """
+    handle_remove_resource(name, ResourceType.COMMAND, "commands", global_install)
+
+
+@app.command("agent")
+def remove_agent(
+    name: Annotated[
+        str,
+        typer.Argument(
+            help="Name of the agent to remove",
+            metavar="NAME",
+        ),
+    ],
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            "-g",
+            help="Remove from ~/.claude/ instead of ./.claude/",
+        ),
+    ] = False,
+) -> None:
+    """Remove a sub-agent from the local installation.
+
+    Removes the agent file immediately without confirmation.
+
+    Examples:
+      agr remove agent hello-agent
+      agr remove agent hello-agent --global
+    """
+    handle_remove_resource(name, ResourceType.AGENT, "agents", global_install)

--- a/src/agr/agr/cli/update.py
+++ b/src/agr/agr/cli/update.py
@@ -1,0 +1,106 @@
+"""Update subcommand for agr - re-fetch resources from GitHub."""
+
+from typing import Annotated
+
+import typer
+
+from agr.cli.common import handle_update_resource
+from agr.fetcher import ResourceType
+
+app = typer.Typer(
+    help="Update skills, commands, or agents from GitHub.",
+    no_args_is_help=True,
+)
+
+
+@app.command("skill")
+def update_skill(
+    skill_ref: Annotated[
+        str,
+        typer.Argument(
+            help="Skill reference: <username>/<skill-name> or <username>/<repo>/<skill-name>",
+            metavar="REFERENCE",
+        ),
+    ],
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            "-g",
+            help="Update in ~/.claude/ instead of ./.claude/",
+        ),
+    ] = False,
+) -> None:
+    """Update a skill by re-fetching from GitHub.
+
+    REFERENCE format:
+      - username/skill-name: re-fetches from github.com/username/agent-resources
+      - username/repo/skill-name: re-fetches from github.com/username/repo
+
+    Examples:
+      agr update skill kasperjunge/hello-world
+      agr update skill kasperjunge/my-repo/hello-world --global
+    """
+    handle_update_resource(skill_ref, ResourceType.SKILL, "skills", global_install)
+
+
+@app.command("command")
+def update_command(
+    command_ref: Annotated[
+        str,
+        typer.Argument(
+            help="Command reference: <username>/<command-name> or <username>/<repo>/<command-name>",
+            metavar="REFERENCE",
+        ),
+    ],
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            "-g",
+            help="Update in ~/.claude/ instead of ./.claude/",
+        ),
+    ] = False,
+) -> None:
+    """Update a slash command by re-fetching from GitHub.
+
+    REFERENCE format:
+      - username/command-name: re-fetches from github.com/username/agent-resources
+      - username/repo/command-name: re-fetches from github.com/username/repo
+
+    Examples:
+      agr update command kasperjunge/hello
+      agr update command kasperjunge/my-repo/hello-world --global
+    """
+    handle_update_resource(command_ref, ResourceType.COMMAND, "commands", global_install)
+
+
+@app.command("agent")
+def update_agent(
+    agent_ref: Annotated[
+        str,
+        typer.Argument(
+            help="Agent reference: <username>/<agent-name> or <username>/<repo>/<agent-name>",
+            metavar="REFERENCE",
+        ),
+    ],
+    global_install: Annotated[
+        bool,
+        typer.Option(
+            "--global",
+            "-g",
+            help="Update in ~/.claude/ instead of ./.claude/",
+        ),
+    ] = False,
+) -> None:
+    """Update a sub-agent by re-fetching from GitHub.
+
+    REFERENCE format:
+      - username/agent-name: re-fetches from github.com/username/agent-resources
+      - username/repo/agent-name: re-fetches from github.com/username/repo
+
+    Examples:
+      agr update agent kasperjunge/hello-agent
+      agr update agent kasperjunge/my-repo/hello-agent --global
+    """
+    handle_update_resource(agent_ref, ResourceType.AGENT, "agents", global_install)


### PR DESCRIPTION
## Summary
- Add `agr update skill/command/agent <reference>` command to re-fetch and update local resources from GitHub
- Add `agr remove skill/command/agent <name>` command to delete local resources immediately
- Both commands support `--global/-g` flag for targeting ~/.claude/ vs ./.claude/

## Changes
- **common.py**: Added `get_local_resource_path()`, `handle_update_resource()`, and `handle_remove_resource()` handler functions
- **update.py**: New file with `skill`, `command`, `agent` subcommands
- **remove.py**: New file with `skill`, `command`, `agent` subcommands  
- **main.py**: Registered the new command groups

## Test plan
- [x] Verified `agr update skill kasperjunge/hello-world` successfully re-fetches
- [x] Verified `agr remove skill <name>` deletes the skill directory
- [x] Verified error handling for non-existent resources
- [x] Verified `--help` output for all new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)