### PR TITLE
fix: update Python version requirement to >=3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Install agr CLI:
 pip install agr
 ```
 
+> Requires Python 3.12 or higher.
+
 Install your first skill:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "agr"
 version = "0.7.1b2"
 description = "Agent Resources - A package and project manager for AI agents."
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 license = "MIT"
 dependencies = [
     "httpx>=0.27",


### PR DESCRIPTION
## Problem

  `agr add anthropics/skills/frontend-design` fails on Python 3.10/3.11 with:

  TarFile.extractall() got an unexpected keyword argument 'filter'

  ## Root Cause

  The code in `fetcher.py` uses `tar.extractall(extract_path, filter="data")`, but the `filter` parameter was [added in Python 3.12](https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall).

  ## Fix

  - Updated `requires-python` from `>=3.10` to `>=3.12` in `pyproject.toml`
  - Added Python version note to README.md