### PR TITLE
Sort and dedupe repo skill suggestions

### DIFF
--- a/agr/commands/add.py
+++ b/agr/commands/add.py
@@ -181,13 +181,17 @@ def _maybe_suggest_repo_skills(
     if not skills:
         return None
 
+    cleaned_skills = sorted({skill for skill in skills if skill})
+    if not cleaned_skills:
+        return None
+
     lines = [
         f"Skill '{repo_name}' not found. "
         f"However, '{owner}/{repo_name}' exists as a repository "
-        f"with {len(skills)} skill(s):",
+        f"with {len(cleaned_skills)} skill(s):",
         "",
     ]
-    for skill in skills:
+    for skill in cleaned_skills:
         lines.append(f"  agr add {owner}/{repo_name}/{skill}")
     lines.append("")
     lines.append("Hint: agr handles use the format: owner/repo/skill-name")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -191,6 +191,29 @@ class TestMaybeSuggestRepoSkills:
         assert "agr add remorses/playwriter/playwright-test" in result
         assert "owner/repo/skill-name" in result
 
+    def test_suggests_sorted_unique_skills(self, monkeypatch):
+        """Suggestions should be sorted and unique."""
+        from agr.commands.add import _maybe_suggest_repo_skills
+        from agr.handle import ParsedHandle
+        from agr.source import SourceResolver, default_sources, DEFAULT_SOURCE_NAME
+
+        handle = ParsedHandle(username="owner", name="repo")
+        resolver = SourceResolver(default_sources(), DEFAULT_SOURCE_NAME)
+
+        monkeypatch.setattr(
+            "agr.commands.add.list_remote_repo_skills",
+            lambda *args, **kwargs: ["beta", "alpha", "beta", ""],
+        )
+
+        result = _maybe_suggest_repo_skills("owner/repo", handle, resolver, None)
+        assert result is not None
+
+        lines = [line.strip() for line in result.splitlines() if line.strip().startswith("agr add")]
+        assert lines == [
+            "agr add owner/repo/alpha",
+            "agr add owner/repo/beta",
+        ]
+
     def test_returns_none_for_three_part_handle(self):
         """Returns None for three-part handles (explicit repo)."""
         from agr.commands.add import _maybe_suggest_repo_skills


### PR DESCRIPTION
## What changed
- Sort and de-duplicate suggested skills when probing a repo
- Filter empty skill names and add coverage for ordering/uniqueness

## Why
- Ensure deterministic, clean suggestions even if the API returns duplicates or unstable ordering

## Testing
- ✅ `pytest -q`
