### PR TITLE
feat: Add GEMINI.md as a canonical instruction file

### DIFF
--- a/agr/commands/sync.py
+++ b/agr/commands/sync.py
@@ -23,7 +23,6 @@ from agr.handle import (
 )
 from agr.instructions import (
     canonical_instruction_file,
-    detect_instruction_files,
     sync_instruction_files,
 )
 from agr.metadata import (
@@ -54,23 +53,32 @@ def _sync_instructions_if_configured(
     if len(tools) < 2:
         return
 
-    existing_files = detect_instruction_files(repo_root)
-    if len(existing_files) < 2:
-        return
-
     if config.canonical_instructions:
         canonical_file = config.canonical_instructions
     else:
         tool_name = config.default_tool or tools[0].name
         canonical_file = canonical_instruction_file(tool_name)
 
-    if canonical_file not in existing_files:
+    # Canonical source must exist — otherwise there is nothing to sync from.
+    if not (repo_root / canonical_file).exists():
         console.print(
             f"[yellow]Instruction sync skipped:[/yellow] {canonical_file} not found."
         )
         return
 
-    updated = sync_instruction_files(repo_root, canonical_file, existing_files)
+    # Build the set of target files from all configured tools (excluding canonical).
+    target_files = sorted(
+        {
+            canonical_instruction_file(tool.name)
+            for tool in tools
+            if canonical_instruction_file(tool.name) != canonical_file
+        }
+    )
+
+    if not target_files:
+        return
+
+    updated = sync_instruction_files(repo_root, canonical_file, target_files)
     if updated:
         updated_list = ", ".join(updated)
         console.print(

--- a/agr/config.py
+++ b/agr/config.py
@@ -16,7 +16,7 @@ from agr.source import (
 )
 from agr.tool import DEFAULT_TOOL_NAMES, TOOLS, ToolConfig, get_tool
 
-VALID_CANONICAL_INSTRUCTIONS = {"AGENTS.md", "CLAUDE.md"}
+VALID_CANONICAL_INSTRUCTIONS = {"AGENTS.md", "CLAUDE.md", "GEMINI.md"}
 
 
 @dataclass
@@ -167,7 +167,7 @@ class AgrConfig:
             canonical_instructions = str(canonical_instructions)
             if canonical_instructions not in VALID_CANONICAL_INSTRUCTIONS:
                 raise ConfigError(
-                    "canonical_instructions must be 'AGENTS.md' or 'CLAUDE.md'"
+                    "canonical_instructions must be 'AGENTS.md', 'CLAUDE.md', or 'GEMINI.md'"
                 )
             config.canonical_instructions = canonical_instructions
 

--- a/agr/instructions.py
+++ b/agr/instructions.py
@@ -3,13 +3,15 @@
 from pathlib import Path
 
 
-INSTRUCTION_FILES = ("CLAUDE.md", "AGENTS.md")
+INSTRUCTION_FILES = ("CLAUDE.md", "AGENTS.md", "GEMINI.md")
 
 
 def canonical_instruction_file(tool_name: str) -> str:
     """Resolve the canonical instruction file for a tool."""
     if tool_name == "claude":
         return "CLAUDE.md"
+    if tool_name == "antigravity":
+        return "GEMINI.md"
     return "AGENTS.md"
 
 
@@ -23,13 +25,16 @@ def sync_instruction_files(
 ) -> list[str]:
     """Sync instruction files to match the canonical file.
 
+    Creates missing instruction files from the canonical source and
+    updates existing ones that differ from the canonical content.
+
     Args:
         repo_root: Repository root path.
         canonical_file: Filename to copy from.
-        files: Existing instruction filenames to update.
+        files: Instruction filenames to sync (will be created if missing).
 
     Returns:
-        List of filenames that were updated.
+        List of filenames that were created or updated.
     """
     canonical_path = repo_root / canonical_file
     if not canonical_path.exists():
@@ -42,9 +47,7 @@ def sync_instruction_files(
         if filename == canonical_file:
             continue
         target_path = repo_root / filename
-        if not target_path.exists():
-            continue
-        if target_path.read_text() != canonical_content:
+        if not target_path.exists() or target_path.read_text() != canonical_content:
             target_path.write_text(canonical_content)
             updated.append(filename)
 

--- a/tests/cli/agr/test_sync.py
+++ b/tests/cli/agr/test_sync.py
@@ -46,3 +46,44 @@ dependencies = []
         assert (cli_project / "AGENTS.md").read_text() == (
             cli_project / "CLAUDE.md"
         ).read_text()
+
+    def test_sync_instructions_creates_gemini_for_antigravity(
+        self, agr, cli_project, cli_config
+    ):
+        """agr sync creates GEMINI.md from CLAUDE.md when antigravity is configured."""
+        (cli_project / "CLAUDE.md").write_text("Claude instructions\n")
+        cli_config(
+            """
+tools = ["claude", "antigravity"]
+sync_instructions = true
+canonical_instructions = "CLAUDE.md"
+dependencies = []
+"""
+        )
+
+        result = agr("sync")
+
+        assert_cli(result).succeeded()
+        assert (cli_project / "GEMINI.md").exists()
+        assert (cli_project / "GEMINI.md").read_text() == "Claude instructions\n"
+
+    def test_sync_instructions_creates_agents_for_cursor(
+        self, agr, cli_project, cli_config
+    ):
+        """agr sync creates AGENTS.md from CLAUDE.md when only CLAUDE.md exists."""
+        (cli_project / "CLAUDE.md").write_text("Claude instructions\n")
+        cli_config(
+            """
+tools = ["claude", "cursor"]
+sync_instructions = true
+canonical_instructions = "CLAUDE.md"
+dependencies = []
+"""
+        )
+
+        result = agr("sync")
+
+        assert_cli(result).succeeded()
+        assert (cli_project / "AGENTS.md").exists()
+        assert (cli_project / "AGENTS.md").read_text() == "Claude instructions\n"
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,15 @@ dependencies = [
         config = AgrConfig.load(config_path)
         assert config.canonical_instructions == "AGENTS.md"
 
+    def test_load_canonical_instructions_gemini(self, tmp_path):
+        """Load config with GEMINI.md as canonical_instructions."""
+        config_path = tmp_path / "agr.toml"
+        config_path.write_text(
+            'canonical_instructions = "GEMINI.md"\ndependencies = []\n'
+        )
+        config = AgrConfig.load(config_path)
+        assert config.canonical_instructions == "GEMINI.md"
+
     def test_load_invalid_canonical_instructions_raises(self, tmp_path):
         """Invalid canonical_instructions raises ConfigError."""
         config_path = tmp_path / "agr.toml"


### PR DESCRIPTION
Introduce `GEMINI.md` as a canonical instruction file for Antigravity and enhance `agr sync` to create missing instruction files for configured tools.
