### PR TITLE
docs: update CLI commands and dependency types documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,8 @@ uv run agrx --help
 
 Two CLI tools share a common core library:
 
-- **`agr`** — Main CLI (Typer app in `agr/main.py`). Commands: add, remove, sync, list, init, config.
+- **`agr`** — Main CLI (Typer app in `agr/main.py`). Commands: init, add, remove, sync, upgrade, list, run, config.
 - **`agrx`** — Ephemeral skill runner (`agrx/main.py`). Downloads and runs a skill without persisting it.
-
-For detailed architecture, contributing guides, code patterns, and recipes, see `docs/contributing/`.
 
 ## agr.toml Format
 
@@ -44,11 +42,11 @@ dependencies = [
 ```
 
 Each dependency has:
-- `type`: Always "skill" for now
+- `type`: `"skill"` or `"ralph"`. Skills install into each configured tool's skills dir; ralphs install once into `.agents/ralphs/<name>/` (project-scoped, no per-tool fan-out, no global installs).
 - `handle`: Remote GitHub reference (username/repo/skill or username/skill)
 - `path`: Local path (alternative to handle)
 
-Future: A `tools` section will configure which tools to sync to:
+The `tools` section configures which tools to sync to:
 ```toml
 tools = ["claude", "cursor"]
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,8 @@ uv run agrx --help
 
 Two CLI tools share a common core library:
 
-- **`agr`** — Main CLI (Typer app in `agr/main.py`). Commands: add, remove, sync, list, init, config.
+- **`agr`** — Main CLI (Typer app in `agr/main.py`). Commands: init, add, remove, sync, upgrade, list, run, config.
 - **`agrx`** — Ephemeral skill runner (`agrx/main.py`). Downloads and runs a skill without persisting it.
-
-For detailed architecture, contributing guides, code patterns, and recipes, see `docs/contributing/`.
 
 ## agr.toml Format
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,8 +40,7 @@ cd my-project
 agr init
 ```
 
-Writes a starter `agr.toml` and adds the per-tool skill directories to
-`.gitignore`.
+Writes a starter `agr.toml`.
 
 ### 3. Add a skill
 

--- a/docs/managing.md
+++ b/docs/managing.md
@@ -80,7 +80,7 @@ Skill directories are built artifacts. Commit the manifest, ignore the build.
 .agents/skills/
 ```
 
-`agr init` writes these for you.
+Add these to your project's `.gitignore` manually.
 
 ## Multi-tool
 


### PR DESCRIPTION
## Summary
Updates documentation to reflect the current state of the `agr` CLI and clarifies the dependency type system, including the new `ralph` type and `tools` configuration section.

## Key Changes
- **CLI commands**: Updated command list in AGENTS.md and CLAUDE.md to include `upgrade` and `run`, and reordered to match actual implementation (init, add, remove, sync, upgrade, list, run, config)
- **Dependency types**: Clarified that `type` can be `"skill"` or `"ralph"`, with explanation of how ralphs install to a project-scoped directory without per-tool fan-out
- **Tools section**: Changed from "Future" to present tense, indicating the `tools` configuration section is now implemented
- **Removed outdated references**: Removed mention of `docs/contributing/` directory and outdated `.gitignore` behavior from `agr init`
- **Gitignore guidance**: Updated to clarify that `.agents/skills/` should be added to `.gitignore` manually rather than automatically by `agr init`

## Implementation Details
These are documentation-only changes reflecting the actual current state of the codebase. No functional code changes are included.

https://claude.ai/code/session_01RoQiPqMvCK3JRVLPo1UfDj