### PR TITLE
docs: recommend `agr upgrade` for iterating on in-repo skills

### DIFF
--- a/skills/agr-cli/SKILL.md
+++ b/skills/agr-cli/SKILL.md
@@ -125,8 +125,11 @@ mkdir -p skills && mv my-skill skills/
 agr add ./skills/my-skill          # records {path = "./skills/my-skill", type = "skill"} in agr.toml
 ```
 
-Iterate: edit `skills/my-skill/SKILL.md`, then
-`agr add ./skills/my-skill --overwrite` to reinstall into each configured tool.
+Iterate: edit `skills/my-skill/SKILL.md`, then `agr upgrade my-skill` to
+reinstall the fresh on-disk copy into each configured tool and refresh
+`agr.lock`. (`agr add ./skills/my-skill --overwrite` also works, but reach for
+it when you've changed the dependency's path or are re-adding it — for plain
+edits to an already-registered skill, `agr upgrade` is shorter and lock-aware.)
 
 Teammates pick it up with `agr sync` after pulling. The local `path` dependency
 travels with the repo, so contributors don't need network access to use it.

--- a/skills/agr-cli/references/in-repo-skills.md
+++ b/skills/agr-cli/references/in-repo-skills.md
@@ -84,11 +84,19 @@ for every tool in `tools`.
 Edit `skills/my-skill/SKILL.md`, then reinstall:
 
 ```bash
-agr add ./skills/my-skill --overwrite
+agr upgrade my-skill
 ```
 
-Or just `agr sync` — but `--overwrite` is more explicit when you've made local
-edits.
+`agr upgrade` reinstalls a fresh on-disk copy of the local skill into every
+configured tool and refreshes `agr.lock` — the canonical re-sync after editing
+an already-registered in-repo skill.
+
+Alternatives:
+
+- `agr add ./skills/my-skill --overwrite` — path-based; reach for it when the
+  skill's path changed or you're re-adding it, not for plain edits.
+- `agr sync` — only installs what's missing, so it won't pick up edits to an
+  already-installed skill. Use `agr upgrade` to force the refresh.
 
 To test ephemerally (no permanent install) on a path:
 


### PR DESCRIPTION
## What

Updates the `agr-cli` skill's in-repo iteration guidance to recommend `agr upgrade <name>` instead of `agr add ./path --overwrite` when re-syncing a locally-edited skill.

## Why

`agr upgrade --help` describes it as: *"Re-install dependencies (latest upstream commit for remotes, fresh copy for local) and refresh agr.lock."* For a vendored/in-repo skill that's exactly the iterate loop — and it's shorter, name-based, and refreshes `agr.lock`, whereas `agr add ./path --overwrite` is path-based and doesn't foreground lockfile hygiene.

## Changes

- `skills/agr-cli/SKILL.md` — Iterate note now leads with `agr upgrade my-skill`; `add --overwrite` kept as the path-based escape hatch for re-adds.
- `skills/agr-cli/references/in-repo-skills.md` — same, plus clarifies that `agr sync` won't pick up edits to an already-installed skill.

Docs-only; `mkdocs build --strict` passes.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)